### PR TITLE
plugins, cli: Hermes (Nous Research) mesh adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Features
 
+* **plugins:** Hermes (Nous Research) Python adapter (`hermes_plugin`), `wrap_hermes()`, and `inai create --framework hermes` ([a696797](https://github.com/ch4r10t33r/inai/commit/a696797))
 * make libp2p the default discovery mode ([80dc7bb](https://github.com/ch4r10t33r/inai/commit/80dc7bb52fe1b7f8d1d5b0be1d28e6988146e33a))
 
 ## [0.2.0](https://github.com/ch4r10t33r/inai/compare/v0.1.1...v0.2.0) (2026-03-27)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Inai is **not a platform** — it is a protocol layer others build on.
 
 | Layer | Role | Technologies |
 |---|---|---|
-| **L4** Execution | Agent frameworks | LangGraph · Google ADK · CrewAI · Agno · LlamaIndex · smolagents · OpenAI Agents |
+| **L4** Execution | Agent frameworks | LangGraph · Google ADK · CrewAI · Agno · LlamaIndex · smolagents · Hermes · OpenAI Agents |
 | **L3** Interaction | Request / response | `AgentRequest` / `AgentResponse` · AMP-2 |
 | **L2** Discovery | Capability lookup | Local · HTTP · libp2p + Kademlia DHT · AMP-1 |
 | **L1** Identity | DID + trust | `did:key` W3C (default) · ERC-8004 on-chain (optional) |
@@ -39,7 +39,7 @@ Inai operates primarily at **L2** and **L3**, bridging L1 identity to L4 framewo
 
 ## Features
 
-- **Framework-agnostic** — wrap LangGraph, Google ADK, CrewAI, Agno, LlamaIndex, smolagents, or OpenAI Agents with one function call
+- **Framework-agnostic** — wrap LangGraph, Google ADK, CrewAI, Agno, LlamaIndex, smolagents, Hermes (Nous Research), or OpenAI Agents with one function call
 - **Built-in HTTP server** — `inai run MyAgent --port 6174` starts a real HTTP server; no extra setup
 - **MCP bridge** — any MCP server becomes a Inai agent; any Inai agent becomes an MCP server (Claude Desktop, Cursor, Continue)
 - **Dynamic discovery** — agents register capabilities; callers query at runtime, no hardcoded URLs
@@ -76,6 +76,7 @@ Inai operates primarily at **L2** and **L3**, bridging L1 identity to L4 framewo
 | **Agno plugin** | ✅ | ✅ | ✅ | ✅ |
 | **LlamaIndex plugin** | ✅ | ✅ | ✅ | ✅ |
 | **smolagents plugin** | ✅ | ✅ | ✅ | ✅ |
+| **Hermes plugin** (Nous Research `AIAgent`) | ✅ | ✅ | ✅ | ✅ |
 | **MCP bridge (wrap MCP servers)** | ✅ | ✅ | ✅ | ✅ |
 | **MCP bridge (expose as MCP server)** | ✅ | ✅ | ✅ | ✅ |
 | **x402 micropayments** | ✅ | ✅ | ✅ | ✅ |
@@ -284,7 +285,7 @@ INAI_DISCOVERY_URL=https://registry.example.com
 |---|---|
 | `inai scaffold <name> [OPTIONS]` | Generate a minimal, targeted agent project (see below) |
 | `inai init <name> [--lang ts\|python\|rust\|zig]` | Copy the full template library into a new project (see below) |
-| `inai create agent <name> [-c cap1,cap2] [--framework X]` | Add an agent to an existing project |
+| `inai create agent <name> [-c cap1,cap2] [--framework X]` | Add an agent to an existing project (`X`: `none`, `google-adk`, `crewai`, `langgraph`, `agno`, `llamaindex`, `smolagents`, `hermes`) |
 | `inai run <AgentName> [--port 6174]` | Start an agent's HTTP server |
 | `inai discover [-c capability] [--host h] [--port p]` | Query the discovery layer |
 | `inai version` | Show CLI version and build info |
@@ -411,6 +412,12 @@ from plugins.agno_plugin       import wrap_agno
 from plugins.llamaindex_plugin import wrap_llamaindex
 from plugins.smolagents_plugin import wrap_smolagents
 
+# Hermes (Nous Research) — Python only; pip install git+https://github.com/NousResearch/hermes-agent.git
+from run_agent import AIAgent
+from plugins.hermes_plugin import wrap_hermes
+_hermes = AIAgent(model="openai/gpt-4o-mini", quiet_mode=True, skip_memory=True, skip_context_files=True)
+agent = wrap_hermes(_hermes, name="HermesBot", agent_id="inai://agent/hermes", owner="0x...", mesh_capabilities=["chat", "research"])
+
 # Serve over HTTP (all plugins share the same interface)
 import asyncio
 asyncio.run(agent.serve(port=6174))
@@ -449,6 +456,8 @@ const agent = wrapOpenAI(oaiAgent, { agentId: 'inai://agent/weather', name: 'Wea
 const agnoAgent     = new AgnoPlugin({ agentId: 'inai://agent/agno', ... }).wrap(myAgnoAgent);
 const llamaAgent    = new LlamaIndexPlugin({ agentId: 'inai://agent/llama', ... }).wrap(myIndex);
 const smolaAgent    = new SmolagentsPlugin({ agentId: 'inai://agent/smol', ... }).wrap(mySmolAgent);
+
+// Hermes (Nous Research) — use `plugins/hermes_plugin.py` + `inai create agent ... --lang python --framework hermes`
 
 await agent.serve({ port: 6174 });
 ```
@@ -494,6 +503,8 @@ let agent = LlamaIndexPlugin::new().wrap(service, PluginConfig { .. });
 let service = SmolagentsService { base_url: "http://localhost:7860".into(), ..Default::default() };
 let agent = SmolagentsPlugin::new().wrap(service, PluginConfig { .. });
 
+// Hermes (Nous Research) — embed via Python `wrap_hermes()` / `inai create ... --framework hermes` (no Rust SDK)
+
 // CrewAI — HTTP bridge to a FastAPI-wrapped crew
 let mut service = CrewAIService { base_url: "http://localhost:8000".into(), ..Default::default() };
 let plugin = CrewAIPlugin::new();
@@ -536,6 +547,8 @@ var lli_service = lli.LlamaIndexService{ .base_url = "http://localhost:8080" };
 
 // smolagents — Gradio or custom API
 var sma_service = sma.SmolagentsService{ .base_url = "http://localhost:7860" };
+
+// Hermes (Nous Research) — no Zig module; use a Python agent with `wrap_hermes()`
 ```
 
 ---
@@ -1092,7 +1105,7 @@ python run_example.py
 | [docs/mcp.md](docs/mcp.md) | MCP bridge — wrap MCP servers, expose as MCP server |
 | [docs/discovery.md](docs/discovery.md) | Discovery adapters |
 | [docs/libp2p.md](docs/libp2p.md) | P2P networking with libp2p + QUIC |
-| [docs/plugins.md](docs/plugins.md) | Framework adapters — LangGraph, Google ADK, CrewAI, OpenAI, Agno, LlamaIndex, smolagents, MCP |
+| [docs/plugins.md](docs/plugins.md) | Framework adapters — LangGraph, Google ADK, CrewAI, OpenAI, Agno, LlamaIndex, smolagents, Hermes, MCP |
 | [docs/differentiation.md](docs/differentiation.md) | How Inai differs from other frameworks |
 | [docs/vs-a2a.md](docs/vs-a2a.md) | Inai vs A2A — detailed technical comparison |
 

--- a/cli/src/commands/create.rs
+++ b/cli/src/commands/create.rs
@@ -37,6 +37,7 @@ pub enum Framework {
     Agno,
     LlamaIndex,
     Smolagents,
+    Hermes,
 }
 
 impl Framework {
@@ -48,6 +49,7 @@ impl Framework {
             "agno" => Self::Agno,
             "llamaindex" => Self::LlamaIndex,
             "smolagents" => Self::Smolagents,
+            "hermes" | "hermesagent" => Self::Hermes,
             _ => Self::None,
         }
     }
@@ -61,6 +63,7 @@ impl Framework {
             Self::Agno => "agno",
             Self::LlamaIndex => "llamaindex",
             Self::Smolagents => "smolagents",
+            Self::Hermes => "hermes",
         }
     }
 
@@ -86,12 +89,18 @@ impl Framework {
                 Some("pip install llama-index llama-index-llms-openai")
             }
             (Self::Smolagents, Lang::Python) => Some("pip install smolagents"),
+            (Self::Hermes, Lang::Python) => {
+                Some("pip install git+https://github.com/NousResearch/hermes-agent.git")
+            }
             _ => None,
         }
     }
 
     fn is_python_only(&self) -> bool {
-        matches!(self, Self::CrewAi | Self::Agno | Self::Smolagents)
+        matches!(
+            self,
+            Self::CrewAi | Self::Agno | Self::Smolagents | Self::Hermes
+        )
     }
 }
 
@@ -475,6 +484,12 @@ export const {name}: IAgent = {{
 // ── Template: TypeScript × smolagents — fallback (Python-only) ───────────────
 
 fn template_ts_smolagents(name: &str, caps: &[String]) -> String {
+    template_ts_none(name, caps)
+}
+
+// ── Template: TypeScript × hermes — fallback (Python-only) ────────────────────
+
+fn template_ts_hermes(name: &str, caps: &[String]) -> String {
     template_ts_none(name, caps)
 }
 
@@ -959,6 +974,60 @@ _agent = ToolCallingAgent(
     )
 }
 
+// ── Template: Python × hermes ─────────────────────────────────────────────────
+
+fn template_py_hermes(name: &str, caps: &[String]) -> String {
+    let snake = snake_case(name);
+
+    let mesh_list = if caps.is_empty() {
+        r#"["chat"]"#.to_string()
+    } else {
+        let inner: Vec<String> = caps.iter().map(|c| format!(r#""{c}""#)).collect();
+        format!("[{}]", inner.join(", "))
+    };
+
+    let tags_dq: Vec<String> = caps.iter().map(|c| format!(r#""{c}""#)).collect();
+    let tags_str = {
+        let mut v = tags_dq.clone();
+        v.push(r#""hermes""#.to_string());
+        v.join(", ")
+    };
+
+    format!(
+        r#""""
+{name} — Nous Research Hermes agent, wrapped for the Inai mesh.
+
+Each name in `mesh_capabilities` is a separate Inai capability; all forward
+to the same Hermes `AIAgent`.  Request payloads use keys: message, task,
+query, or input.
+
+Install: pip install git+https://github.com/NousResearch/hermes-agent.git
+Docs: https://hermes-agent.nousresearch.com/docs/guides/python-library
+"""
+from run_agent                  import AIAgent
+from plugins.hermes_plugin      import wrap_hermes
+
+
+_agent = AIAgent(
+    model="openai/gpt-4o-mini",
+    quiet_mode=True,
+    skip_memory=True,
+    skip_context_files=True,
+)
+
+
+{name} = wrap_hermes(
+    agent             = _agent,
+    name              = "{name}",
+    agent_id          = "inai://agent/{snake}",
+    owner             = "0xYourWalletAddress",
+    tags              = [{tags_str}],
+    mesh_capabilities = {mesh_list},
+)
+"#
+    )
+}
+
 // ── Template: Rust × none ─────────────────────────────────────────────────────
 
 fn template_rs_none(name: &str, caps: &[String]) -> String {
@@ -1024,6 +1093,10 @@ fn template_rs_smolagents(name: &str, caps: &[String]) -> String {
     template_rs_none(name, caps)
 }
 
+fn template_rs_hermes(name: &str, caps: &[String]) -> String {
+    template_rs_none(name, caps)
+}
+
 // ── Template: Zig × none ──────────────────────────────────────────────────────
 
 fn template_zig_none(name: &str, caps: &[String]) -> String {
@@ -1086,6 +1159,10 @@ fn template_zig_smolagents(name: &str, caps: &[String]) -> String {
     template_zig_none(name, caps)
 }
 
+fn template_zig_hermes(name: &str, caps: &[String]) -> String {
+    template_zig_none(name, caps)
+}
+
 // ── Template dispatch ─────────────────────────────────────────────────────────
 
 fn generate(lang: &Lang, framework: &Framework, name: &str, caps: &[String]) -> String {
@@ -1098,6 +1175,7 @@ fn generate(lang: &Lang, framework: &Framework, name: &str, caps: &[String]) -> 
         (Lang::TypeScript, Framework::Agno) => template_ts_agno(name, caps),
         (Lang::TypeScript, Framework::LlamaIndex) => template_ts_llamaindex(name, caps),
         (Lang::TypeScript, Framework::Smolagents) => template_ts_smolagents(name, caps),
+        (Lang::TypeScript, Framework::Hermes) => template_ts_hermes(name, caps),
         // Python
         (Lang::Python, Framework::None) => template_py_none(name, caps),
         (Lang::Python, Framework::GoogleAdk) => template_py_google_adk(name, caps),
@@ -1106,6 +1184,7 @@ fn generate(lang: &Lang, framework: &Framework, name: &str, caps: &[String]) -> 
         (Lang::Python, Framework::Agno) => template_py_agno(name, caps),
         (Lang::Python, Framework::LlamaIndex) => template_py_llamaindex(name, caps),
         (Lang::Python, Framework::Smolagents) => template_py_smolagents(name, caps),
+        (Lang::Python, Framework::Hermes) => template_py_hermes(name, caps),
         // Rust
         (Lang::Rust, Framework::None) => template_rs_none(name, caps),
         (Lang::Rust, Framework::GoogleAdk) => template_rs_google_adk(name, caps),
@@ -1114,6 +1193,7 @@ fn generate(lang: &Lang, framework: &Framework, name: &str, caps: &[String]) -> 
         (Lang::Rust, Framework::Agno) => template_rs_agno(name, caps),
         (Lang::Rust, Framework::LlamaIndex) => template_rs_llamaindex(name, caps),
         (Lang::Rust, Framework::Smolagents) => template_rs_smolagents(name, caps),
+        (Lang::Rust, Framework::Hermes) => template_rs_hermes(name, caps),
         // Zig
         (Lang::Zig, Framework::None) => template_zig_none(name, caps),
         (Lang::Zig, Framework::GoogleAdk) => template_zig_google_adk(name, caps),
@@ -1122,6 +1202,7 @@ fn generate(lang: &Lang, framework: &Framework, name: &str, caps: &[String]) -> 
         (Lang::Zig, Framework::Agno) => template_zig_agno(name, caps),
         (Lang::Zig, Framework::LlamaIndex) => template_zig_llamaindex(name, caps),
         (Lang::Zig, Framework::Smolagents) => template_zig_smolagents(name, caps),
+        (Lang::Zig, Framework::Hermes) => template_zig_hermes(name, caps),
     }
 }
 

--- a/docs/differentiation.md
+++ b/docs/differentiation.md
@@ -70,7 +70,7 @@ SentriX introduces a **protocol layer for agents**, analogous to how TCP/IP enab
 ### Core Principles
 
 1. **Framework Agnostic**
-   - Agents can be built using any framework (LangGraph, Google ADK, etc.)
+   - Agents can be built using any framework (LangGraph, Google ADK, Hermes, etc.)
    - SentriX provides adapters/plugins for interoperability
 
 2. **Discoverability by Design**

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,7 +7,7 @@ Inai has a two-way bridge with the [Model Context Protocol (MCP)](https://modelc
 | **MCP → Inai** | Any MCP server becomes a Inai agent | `MCPPlugin` |
 | **Inai → MCP** | Any Inai agent becomes an MCP server | `serve_as_mcp()` / `serveAsMcp()` |
 
-This makes Inai the interoperability hub between MCP's vast tool ecosystem (GitHub, filesystem, Slack, databases, web search…) and every agent framework Inai supports (Google ADK, CrewAI, LangGraph, Agno, smolagents, and more).
+This makes Inai the interoperability hub between MCP's vast tool ecosystem (GitHub, filesystem, Slack, databases, web search…) and every agent framework Inai supports (Google ADK, CrewAI, LangGraph, Agno, smolagents, Hermes, and more).
 
 ---
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -33,7 +33,7 @@ Switch between them with a single environment variable (`INAI_DISCOVERY_URL`) or
 
 ### 3. Framework-agnostic by design
 
-Inai does not care how your agent is built. Bring your existing LangGraph graph, Google ADK agent, or custom logic and wrap it with a **InaiPlugin** in one function call:
+Inai does not care how your agent is built. Bring your existing LangGraph graph, Google ADK agent, Hermes (`AIAgent`), or custom logic and wrap it with a **InaiPlugin** in one function call:
 
 ```python
 agent = wrap_langgraph(graph, name="Researcher", agent_id="inai://agent/researcher")
@@ -72,7 +72,7 @@ inai/
     ├── anr.md                  # Agent Network Record spec
     ├── interfaces.md           # IAgent · IAgentRequest · IAgentResponse · IAgentDiscovery
     ├── discovery.md            # Discovery layer & adapters
-    ├── plugins.md              # InaiPlugin · LangGraph · Google ADK
+    ├── plugins.md              # InaiPlugin · LangGraph · Google ADK · Hermes · …
     ├── version-management.md   # Versioning & changelog policy
     └── examples/
         ├── 01-hello-agent.md         # Defining your first agent

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -160,6 +160,66 @@ await agent.register_discovery()
 
 ---
 
+## Hermes plugin (Nous Research)
+
+Wraps a Hermes [`AIAgent`](https://hermes-agent.nousresearch.com/docs/guides/python-library) from `run_agent`. Hermes is a full agent runtime (built-in toolsets); Inai **mesh capabilities** are configurable labels that all route to the same `chat()` or `run_conversation()` entrypoint — unlike CrewAI/LangGraph, you do not register arbitrary Python `@tool` functions per capability.
+
+### Install
+
+Hermes is often installed from source (not always on PyPI):
+
+```bash
+pip install git+https://github.com/NousResearch/hermes-agent.git
+```
+
+Set provider keys as documented upstream (for example `OPENROUTER_API_KEY`).
+
+### Usage
+
+```python
+from run_agent import AIAgent
+from plugins.hermes_plugin import wrap_hermes
+
+_agent = AIAgent(
+    model="openai/gpt-4o-mini",
+    quiet_mode=True,
+    skip_memory=True,
+    skip_context_files=True,
+)
+
+agent = wrap_hermes(
+    agent=_agent,
+    name="HermesMesh",
+    agent_id="inai://agent/hermes",
+    owner="0xYourWallet",
+    tags=["hermes", "nous"],
+    mesh_capabilities=["chat", "research"],
+)
+
+await agent.register_discovery()
+```
+
+Callers should send a user message in the payload using one of: `message`, `task`, `query`, or `input`. Optional keys: `run_conversation`, `task_id`, `system_message`, `conversation_history`.
+
+### Config options (`HermesPluginConfig`)
+
+| Option | Default | Description |
+|---|---|---|
+| `mesh_capabilities` | `["chat"]` | Capability names advertised on the mesh |
+| `use_run_conversation` | `False` | Default to `run_conversation` instead of `chat()` |
+| `prefix_capability_in_message` | `True` | Prefix with `[Inai capability: …]` for context |
+| `default_task_id` | `None` | Fixed `task_id` for `run_conversation` when not supplied per request |
+
+Other fields inherit from `PluginConfig` (identity, discovery, `timeout_ms`, etc.).
+
+### CLI scaffolding
+
+```bash
+inai create agent MyHermes --lang python --framework hermes -c chat,research
+```
+
+---
+
 ## Writing a custom plugin
 
 To integrate any other framework, subclass `InaiPlugin` and implement the four methods:

--- a/docs/vs-a2a.md
+++ b/docs/vs-a2a.md
@@ -112,7 +112,7 @@ This matters for:
 
 **A2A:** Framework-agnostic in theory, but most implementations are Python or TypeScript. There is no native concept of "this agent runs LangGraph" vs "this agent runs CrewAI".
 
-**Inai:** First-class framework plugins for LangGraph, Google ADK, CrewAI, OpenAI Agents SDK, Agno, LlamaIndex, smolagents, and MCP — in TypeScript, Rust, and Zig. A LangGraph agent and a CrewAI agent and a Rust agent all speak the same Inai mesh protocol. Framework identity is part of the ANR.
+**Inai:** First-class framework plugins for LangGraph, Google ADK, CrewAI, OpenAI Agents SDK, Agno, LlamaIndex, smolagents, Hermes (Nous Research), and MCP — in TypeScript, Rust, and Zig. A LangGraph agent and a CrewAI agent and a Rust agent all speak the same Inai mesh protocol. Framework identity is part of the ANR.
 
 ### 8. Embedded and Resource-Constrained Deployment
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ program
   .description('Generate a new agent inside an existing Inai project')
   .option('-l, --lang <language>', 'Target language (auto-detected from project if omitted)')
   .option('-c, --capabilities <caps>', 'Comma-separated list of capability names', 'exampleCapability')
-  .option('-f, --framework <framework>', 'Agent framework: none | google-adk | crewai | langgraph | agno | llamaindex | smolagents', 'none')
+  .option('-f, --framework <framework>', 'Agent framework: none | google-adk | crewai | langgraph | agno | llamaindex | smolagents | hermes', 'none')
   .option('--addon <addon>', 'Optional add-on: x402')
   .option('-y, --yes', 'Skip confirmation prompts and auto-install dependencies')
   .action(createCommand);

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -9,7 +9,7 @@ import { logger }         from '../utils/logger';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-export type Framework = 'none' | 'google-adk' | 'crewai' | 'langgraph' | 'agno' | 'llamaindex' | 'smolagents';
+export type Framework = 'none' | 'google-adk' | 'crewai' | 'langgraph' | 'agno' | 'llamaindex' | 'smolagents' | 'hermes';
 
 interface CreateOptions {
   lang?:         string;
@@ -52,6 +52,9 @@ const INSTALL_HINTS: Record<Framework, Partial<Record<string, string>>> = {
   },
   'smolagents': {
     python: 'pip install smolagents',
+  },
+  'hermes': {
+    python: 'pip install git+https://github.com/NousResearch/hermes-agent.git',
   },
 };
 
@@ -594,6 +597,53 @@ ${name} = wrap_smolagents(
 `,
 };
 
+// ── FRAMEWORK: hermes ─────────────────────────────────────────────────────────
+
+const HERMES_TEMPLATES: LangTemplates = {
+
+  python: (name, caps) => {
+    const meshList =
+      caps.length > 0
+        ? `[${caps.map(c => `"${c}"`).join(', ')}]`
+        : '["chat"]';
+    const tagInner =
+      caps.length > 0
+        ? `${caps.map(c => `"${c}"`).join(', ')}, "hermes"`
+        : '"hermes"';
+    return `"""
+${name} — Nous Research Hermes agent, wrapped for the Inai mesh.
+
+Each name in \`mesh_capabilities\` is a separate Inai capability; all forward
+to the same Hermes \`AIAgent\`.  Request payloads use keys: message, task,
+query, or input.
+
+Install: pip install git+https://github.com/NousResearch/hermes-agent.git
+Docs: https://hermes-agent.nousresearch.com/docs/guides/python-library
+"""
+from run_agent                  import AIAgent
+from plugins.hermes_plugin      import wrap_hermes
+
+
+_agent = AIAgent(
+    model="openai/gpt-4o-mini",
+    quiet_mode=True,
+    skip_memory=True,
+    skip_context_files=True,
+)
+
+
+${name} = wrap_hermes(
+    agent             = _agent,
+    name              = "${name}",
+    agent_id          = "inai://agent/${toSnake(name)}",
+    owner             = "0xYourWalletAddress",
+    tags              = [${tagInner}],
+    mesh_capabilities = ${meshList},
+)
+`;
+  },
+};
+
 // ── Template dispatch table ───────────────────────────────────────────────────
 
 const FRAMEWORK_TEMPLATES: Record<Framework, LangTemplates> = {
@@ -604,6 +654,7 @@ const FRAMEWORK_TEMPLATES: Record<Framework, LangTemplates> = {
   'agno':        AGNO_TEMPLATES,
   'llamaindex':  LLAMAINDEX_TEMPLATES,
   'smolagents':  SMOLAGENTS_TEMPLATES,
+  'hermes':      HERMES_TEMPLATES,
 };
 
 // ── createCommand ─────────────────────────────────────────────────────────────
@@ -718,7 +769,7 @@ export async function createCommand(
   }
 
   // Some frameworks are Python-only — print a note if user asked for another language
-  const PYTHON_ONLY_FRAMEWORKS: Framework[] = ['crewai', 'agno', 'smolagents'];
+  const PYTHON_ONLY_FRAMEWORKS: Framework[] = ['crewai', 'agno', 'smolagents', 'hermes'];
   if (PYTHON_ONLY_FRAMEWORKS.includes(framework) && lang !== 'python') {
     console.log('');
     console.log(chalk.yellow(

--- a/templates/python/plugins/__init__.py
+++ b/templates/python/plugins/__init__.py
@@ -13,6 +13,7 @@ Available plugins:
   Agno           agno_plugin.py            wrap_agno()
   LlamaIndex     llamaindex_plugin.py      wrap_llamaindex()
   smolagents     smolagents_plugin.py      wrap_smolagents()
+  Hermes         hermes_plugin.py          wrap_hermes()
 
 Adding a new framework:
   1. Create  plugins/my_framework_plugin.py

--- a/templates/python/plugins/example_usage.py
+++ b/templates/python/plugins/example_usage.py
@@ -175,7 +175,54 @@ async def example_multi_framework():
     print("All agents on mesh:", [a.agent_id for a in await registry.list_all()])
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Example 3: Hermes (Nous Research) → Inai
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def example_hermes():
+    """
+    Wraps a Hermes AIAgent as mesh capabilities (git install, provider API keys).
+    """
+    try:
+        from run_agent import AIAgent
+    except ImportError:
+        print("[skip] Hermes not installed (pip install git+https://github.com/NousResearch/hermes-agent.git)")
+        return
+
+    from plugins.hermes_plugin import wrap_hermes
+
+    _agent = AIAgent(
+        model="openai/gpt-4o-mini",
+        quiet_mode=True,
+        skip_memory=True,
+        skip_context_files=True,
+    )
+
+    agent = wrap_hermes(
+        agent=_agent,
+        name="HermesDemo",
+        agent_id="inai://agent/hermes_demo",
+        owner="0xYourWalletAddress",
+        tags=["hermes", "demo"],
+        mesh_capabilities=["chat", "research"],
+    )
+
+    print("Capabilities:", agent.get_capabilities())
+
+    from interfaces import AgentRequest
+
+    req = AgentRequest(
+        request_id="req-hermes-1",
+        from_id="0xCaller",
+        capability="chat",
+        payload={"message": "Say hello in one short sentence."},
+    )
+    resp = await agent.handle_request(req)
+    print("Response:", resp.result)
+
+
 if __name__ == "__main__":
     asyncio.run(example_multi_framework())   # works without any ML deps
     # asyncio.run(example_langgraph())       # requires LangGraph + OpenAI key
     # asyncio.run(example_google_adk())      # requires google-adk + Gemini key
+    # asyncio.run(example_hermes())          # requires hermes-agent + provider keys

--- a/templates/python/plugins/hermes_plugin.py
+++ b/templates/python/plugins/hermes_plugin.py
@@ -1,0 +1,258 @@
+"""
+HermesPlugin — Inai adapter for Nous Research Hermes agents.
+
+Hermes is a full autonomous agent (built-in toolsets: web, browser, terminal, …).
+It does not expose arbitrary Python @tools like CrewAI; instead each Inai
+*capability* you advertise becomes a labeled channel that forwards to the same
+`AIAgent.chat()` / `run_conversation()` entrypoint.
+
+Install (from upstream — not always on PyPI):
+    pip install git+https://github.com/NousResearch/hermes-agent.git
+
+Environment: set `OPENROUTER_API_KEY` and/or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
+per Hermes docs. Use `quiet_mode=True` on `AIAgent` when embedding.
+
+Docs: https://hermes-agent.nousresearch.com/docs/guides/python-library
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from plugins.base import (
+    InaiPlugin,
+    PluginConfig,
+    CapabilityDescriptor,
+    WrappedAgent,
+)
+from interfaces.agent_request import AgentRequest
+from interfaces.agent_response import AgentResponse
+
+# ── Optional Hermes import (git install) ──────────────────────────────────────
+
+try:
+    from run_agent import AIAgent as HermesAIAgent
+
+    _HERMES_OK = True
+except ImportError:
+    _HERMES_OK = False
+    HermesAIAgent = Any  # type: ignore[assignment,misc]
+
+
+# ── Plugin config ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class HermesPluginConfig(PluginConfig):
+    """
+    Inai-side settings for a Hermes `AIAgent`.
+
+    `mesh_capabilities` lists the capability names published on the mesh (e.g.
+    echo, research). Each maps to the same Hermes runtime; the capability name
+    is prefixed into the user message unless disabled.
+    """
+
+    mesh_capabilities: List[str] = field(default_factory=lambda: ["chat"])
+    """Capability names advertised via discovery (default: a single `chat`)."""
+
+    use_run_conversation: bool = False
+    """If True, always use `run_conversation` instead of `chat()`."""
+
+    prefix_capability_in_message: bool = True
+    """Prefix requests with `[Inai capability: …]` so Hermes can specialize."""
+
+    default_task_id: Optional[str] = None
+    """Optional fixed task_id for `run_conversation`; otherwise a UUID per call."""
+
+
+# ── Plugin ────────────────────────────────────────────────────────────────────
+
+
+class HermesPlugin(InaiPlugin):
+    """Bridge Inai `AgentRequest` ↔ Hermes `AIAgent.chat` / `run_conversation`."""
+
+    def __init__(self, config: HermesPluginConfig):
+        if not _HERMES_OK:
+            raise ImportError(
+                "Hermes agent is not installed — run:\n"
+                "  pip install git+https://github.com/NousResearch/hermes-agent.git"
+            )
+        super().__init__(config)
+        self._cfg: HermesPluginConfig = config
+        if not self._cfg.mesh_capabilities:
+            self._cfg.mesh_capabilities = ["chat"]
+
+    def extract_capabilities(self, agent: HermesAIAgent) -> List[CapabilityDescriptor]:
+        del agent  # Hermes tools are internal; we only advertise configured names.
+        return [
+            CapabilityDescriptor(
+                name=c,
+                description=(
+                    f"Hermes (Nous Research) agent — capability `{c}`. "
+                    "Send message/task in payload keys: message, task, query, or input."
+                ),
+                native_name=c,
+            )
+            for c in self._cfg.mesh_capabilities
+        ]
+
+    def translate_request(
+        self,
+        req: AgentRequest,
+        descriptor: CapabilityDescriptor,
+    ) -> dict[str, Any]:
+        pl = req.payload
+        body = (
+            pl.get("message")
+            or pl.get("task")
+            or pl.get("query")
+            or pl.get("input")
+            or str(pl)
+        )
+        if self._cfg.prefix_capability_in_message:
+            user_message = f"[Inai capability: {descriptor.name}]\n{body}"
+        else:
+            user_message = str(body)
+
+        use_rc = bool(
+            pl.get("run_conversation")
+            or pl.get("use_run_conversation")
+            or self._cfg.use_run_conversation
+        )
+        return {
+            "user_message": user_message,
+            "use_run_conversation": use_rc,
+            "task_id": pl.get("task_id"),
+            "system_message": pl.get("system_message"),
+            "conversation_history": pl.get("conversation_history"),
+        }
+
+    async def invoke_native(
+        self,
+        agent: HermesAIAgent,
+        descriptor: CapabilityDescriptor,
+        native_input: dict[str, Any],
+    ) -> Any:
+        del descriptor
+        loop = asyncio.get_event_loop()
+
+        if native_input.get("use_run_conversation"):
+
+            def _run_conv() -> Any:
+                tid = (
+                    native_input.get("task_id")
+                    or self._cfg.default_task_id
+                    or str(uuid.uuid4())
+                )
+                kw: dict[str, Any] = {
+                    "user_message": native_input["user_message"],
+                    "task_id": tid,
+                }
+                if native_input.get("system_message"):
+                    kw["system_message"] = native_input["system_message"]
+                if native_input.get("conversation_history") is not None:
+                    kw["conversation_history"] = native_input["conversation_history"]
+                return agent.run_conversation(**kw)
+
+            return await loop.run_in_executor(None, _run_conv)
+
+        return await loop.run_in_executor(
+            None,
+            lambda: agent.chat(native_input["user_message"]),
+        )
+
+    def translate_response(self, native_result: Any, request_id: str) -> AgentResponse:
+        if isinstance(native_result, dict) and "final_response" in native_result:
+            return AgentResponse.success(
+                request_id,
+                {
+                    "content": native_result["final_response"],
+                    "messages_count": len(native_result.get("messages", [])),
+                    "task_id": native_result.get("task_id"),
+                },
+            )
+        return AgentResponse.success(request_id, {"content": str(native_result)})
+
+
+# ── Convenience wrapper ───────────────────────────────────────────────────────
+
+
+def wrap_hermes(
+    agent: HermesAIAgent,
+    name: str,
+    agent_id: str,
+    owner: str,
+    tags: Optional[List[str]] = None,
+    mesh_capabilities: Optional[List[str]] = None,
+    use_run_conversation: bool = False,
+    prefix_capability_in_message: bool = True,
+    **kwargs: Any,
+) -> WrappedAgent:
+    """
+    Wrap a Hermes `AIAgent` for the Inai mesh.
+
+    Args:
+        agent: Configured `AIAgent` (typically `quiet_mode=True`).
+        name: Display name for discovery.
+        agent_id: Unique URI, e.g. `inai://agent/hermes`.
+        owner: Owner wallet or id.
+        tags: Extra discovery tags.
+        mesh_capabilities: Capability names to advertise (default: `["chat"]`).
+        use_run_conversation: Default to `run_conversation` instead of `chat()`.
+        prefix_capability_in_message: Prefix with capability label for routing context.
+        **kwargs: Forwarded to `HermesPluginConfig` / `PluginConfig` where recognized.
+
+    Example::
+
+        from run_agent import AIAgent
+        from plugins.hermes_plugin import wrap_hermes
+
+        _agent = AIAgent(
+            model="openai/gpt-4o-mini",
+            quiet_mode=True,
+            skip_memory=True,
+            skip_context_files=True,
+        )
+
+        hermes_mesh = wrap_hermes(
+            agent=_agent,
+            name="HermesAgent",
+            agent_id="inai://agent/hermes",
+            owner="0xYourWallet",
+            tags=["hermes", "nous"],
+            mesh_capabilities=["research", "summarize"],
+        )
+    """
+    known = (
+        "version",
+        "description",
+        "metadata_uri",
+        "host",
+        "port",
+        "protocol",
+        "tls",
+        "discovery_type",
+        "discovery_url",
+        "discovery_key",
+        "signing_key",
+        "identity_mode",
+        "timeout_ms",
+        "capability_map",
+        "default_task_id",
+    )
+    extra = {k: v for k, v in kwargs.items() if k in known}
+    caps = mesh_capabilities if mesh_capabilities else ["chat"]
+    cfg = HermesPluginConfig(
+        name=name,
+        agent_id=agent_id,
+        owner=owner,
+        tags=tags or [],
+        mesh_capabilities=caps,
+        use_run_conversation=use_run_conversation,
+        prefix_capability_in_message=prefix_capability_in_message,
+        **extra,
+    )
+    return HermesPlugin(cfg).wrap(agent)

--- a/templates/python/requirements.txt
+++ b/templates/python/requirements.txt
@@ -19,3 +19,7 @@ mcp>=1.0.0
 # pip install openai-agents
 # export OPENAI_API_KEY=sk-...
 openai-agents>=0.0.3
+
+# Hermes / Nous Research (optional — only if using HermesPlugin)
+# pip install git+https://github.com/NousResearch/hermes-agent.git
+# export OPENROUTER_API_KEY=...  (see https://hermes-agent.nousresearch.com/)


### PR DESCRIPTION
## Summary

Adds a Python **Hermes** integration for Nous Research `run_agent.AIAgent`, plus CLI scaffolding and documentation.

## Changes

- **`templates/python/plugins/hermes_plugin.py`** — `HermesPlugin`, `HermesPluginConfig`, `wrap_hermes()`; optional import from `run_agent` (git install).
- **Rust CLI** (`cli/src/commands/create.rs`) — `Framework::Hermes`, `--framework hermes` / `hermesagent`, Python template, TS/Rust/Zig fallbacks (plain IAgent).
- **TypeScript CLI** (`src/cli.ts`, `src/commands/create.ts`) — same framework flag and Python-only template.
- **Templates** — `plugins/__init__.py`, commented install in `requirements.txt`, `example_usage.example_hermes()`.
- **Docs** — README, `docs/plugins.md`, overview, MCP, vs-a2a, differentiation, CHANGELOG.

## Install (consumers)

```bash
pip install git+https://github.com/NousResearch/hermes-agent.git
```

Set provider API keys per [Hermes docs](https://hermes-agent.nousresearch.com/docs/guides/python-library).

## Commits

- `a696797` — plugins, cli: add Hermes mesh adapter and scaffolding
- `7beb394` — docs: document Hermes plugin and create --framework hermes
